### PR TITLE
fix wild water usage without canteen

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -34,6 +34,7 @@ RegisterNetEvent('bcc-water:CheckEmpty', function()
         TriggerClientEvent('bcc-water:FillCanteen', _source)
     else
         VORPcore.NotifyRightTip(_source, _U('needcanteen'), 5000)
+        TriggerClientEvent('bcc-water:Filling', _source)
     end
 end)
 


### PR DESCRIPTION
trigger existing client event to set filling variable to false and allow wild water usage without canteen in inventory